### PR TITLE
option to enable manually stepping through global timeline

### DIFF
--- a/lib/src/tweener.dart
+++ b/lib/src/tweener.dart
@@ -30,7 +30,13 @@ class Tweener {
     }
   }
 
+  static bool _enableManualUpdate = false;
+  static void enableManualUpdate() {
+    _enableManualUpdate = true;
+  }
+
   static void setup() {
+    if (_enableManualUpdate) return;
     Miticker.init(Tweener._tickerHandler);
     Miticker.start();
   }


### PR DESCRIPTION
This allows you to manually step through the global animation timeline (call `Tweener.enableManualUpdate()` on launch then manually call `Tweener.update(your_custom_millis)` each new frame. This is useful for cases such as stepping through a canvas animation and saving frames or setting up a mechanic for pausing all animations.